### PR TITLE
Shrink distributable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-gears-cypress",
-  "version": "5.19.1",
+  "version": "5.19.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appfolio/react-gears-cypress",
-  "version": "5.19.1",
+  "version": "5.19.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Verified by publishing `5.9.2` (from a feature branch, ugh -- I really need to sit down and figure out how to gel the `npm version` workflow with the GitHub PR workflow.)