### PR TITLE
ct - Automatically match spaces at end of line in fuzzyMultiline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@AppFolio-IM/react-gears-cypress",
-  "version": "5.22.0",
+  "version": "5.23.0",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"

--- a/src/match.ts
+++ b/src/match.ts
@@ -33,4 +33,4 @@ export const fuzzyFirstLast = (first: string, last: string) =>
 // Good for dealing with HTML elements that have a multi-line value, but need to be matched with a
 // value from single-line Gherkin table cell. (cucumber-js doesn't grok \n unfortunately!)
 export const fuzzyMultiline = (value: string) =>
-  new RegExp(`^${Cypress._.escapeRegExp(value)}$`.replace(/\s+/g, '\\s+'), 'm');
+  new RegExp(`^${Cypress._.escapeRegExp(value)}\\s*$`.replace(/\s+/g, '\\s+'), 'm');


### PR DESCRIPTION
If you are trying to match this:

```
          <p className="text-center">
            No contacts have been added yet. <br />
            <a href={urlGenerator.help('/s/article/Tracking-Prospects').url}>
              Learn how to add prospects. <Icon name="external-link" />
            </a>
          </p>
```

With this : 
```
    Then I should see a "Prospects (0)" block with text:
      """
      No contacts have been added yet.
      Learn how to add prospects. 
      """
```

It is easy to oversee that you need to add an extra space at the end of  "Learn how to add prospects. " and you can waste a lot of time trying to figure out what is going on (that happened to me).

This PR makes fuzzyMultiline automatically match this space and avoid this situation.