### PR TITLE
md - update .github/dependabot.yml to use just-for-this-public-repo r…

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@ registries:
     url: https://npm.pkg.github.com/
     username: appf-im-tooling
     # Format of "password" is "username:password" base64 encoded
-    password: ${{secrets.NPM_GITHUB_PACKAGES_RO_PASSWORD}}
+    password: ${{secrets.CYPRESS_REACT_GEARS_NPM_GITHUB_PACKAGES_RO_PASSWORD}}
 updates:
 - package-ecosystem: npm
   directory: "/"


### PR DESCRIPTION
…eadonly package token secret
----
- updates dependabot to use a repo-scoped github secret that has packages:read so it can do its npm installing of github package dependencies.
