### PR TITLE
Conform to Cypress 12's more stringent typings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,8 +18,6 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:cypress/recommended',
     'plugin:react/recommended',
-    // NB: please leave these at the end so they can override all other rules!
-    'prettier/@typescript-eslint',
     'plugin:prettier/recommended'
   ],
   parserOptions: {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,15 @@
 #   - dual publication (to NPM, then GitHub)
 #   - single package per repo (no mono-repo support)
 name: publish
-
 on:
   release:
     types: [published]
-
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,11 @@ jobs:
     strategy:
       matrix:
         cypress-version: ["11", "12"]
-        node-version: ["16.x", "18.x"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
       - run: npm ci
       - run: npm install --save=false cypress@${{ matrix.cypress-version }}
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,26 @@
 name: test
-
 on:
   push:
     branches:
       - main
   pull_request:
-
 jobs:
-  test:
-    name: test
-
+  lint:
     runs-on: ubuntu-latest
-
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run type-check
+  test:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cypress-version: ["11", "12"]
         node-version: ["16.x", "18.x"]
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,39 +1,14 @@
 {
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "eslint.enable": true,
-  "eslint.autoFixOnSave": true,
   "eslint.options": {
     "rules": {
       "no-console": "off",
       "no-debugger": "off"
     }
   },
-  "eslint.packageManager": "npm",
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    {
-      "language": "typescript",
-      "autoFix": true
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true
-    }
-  ],
-  "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[javascriptreact]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescriptreact]": {
-    "editor.formatOnSave": false
-  },
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+  "eslint.packageManager": "npm"
 }

--- a/cypress/component/commands/click.cy.jsx
+++ b/cypress/component/commands/click.cy.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {
+  BlockPanel,
+  Button,
+  Icon,
+} from '@appfolio/react-gears';
+
+// NB: this package will stop overriding cy.click; the test is still useful to
+// prove that Cypress behavior does not regress (thereby requiring an override again).
+describe('cy.click', () => {
+  it('deals with FontAwesome buttons', () => {
+    cy.mount(
+      <div>
+        <Button><Icon name="times"/></Button>
+      </div>
+    );
+
+    cy.get('button').click();
+  });
+});

--- a/cypress/component/index.cy.jsx
+++ b/cypress/component/index.cy.jsx
@@ -2,25 +2,6 @@ import React from 'react';
 import { find, match } from '../../src/index';
 
 describe('react-gears-cypress', () => {
-  context('versioning', () => {
-    // @TODO switch to  @appfolio/react-gears-cypress
-    it.skip('is in lockstep with react-gears', () => {
-      cy.readFile('package.json').then((spec) => {
-        const verRGC = spec.version.replace(/-.*$/, '');
-        const verRG = spec.devDependencies['react-gears'];
-        expect(verRGC).to.equal(verRG);
-      });
-    });
-
-    it('tests a reasonable Cypress version', () => {
-      cy.readFile('package.json').then((spec) => {
-        const peerCypress = spec.peerDependencies['cypress'];
-        const devCypress = spec.devDependencies['cypress'];
-        expect(peerCypress).to.equal(devCypress);
-      });
-    });
-  });
-
   context('deprecated exports', () => {
     it('regexp helpers', () => {
       expect(find).not.to.be.null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "babel-loader": "^9.1.0",
-        "cypress": "*",
+        "cypress": ">= 12.0.0",
         "eslint": "^8.29.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-cypress": "^2.11.1",
@@ -4415,9 +4415,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4468,7 +4468,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/bluebird": {
@@ -11236,9 +11236,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.2.0.tgz",
+      "integrity": "sha512-kvl95ri95KK8mAy++tEU/wUgzAOMiIciZSL97LQvnOinb532m7dGvwN0mDSIGbOd71RREtmT9o4h088RjK5pKw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "babel-loader": "^9.1.0",
-    "cypress": "*",
+    "cypress": ">= 12.0.0",
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.11.1",

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -1,4 +1,4 @@
-import { QUIET, FORCE_QUIET, isJQuery } from './internals/constants';
+import { QUIET, FORCE_QUIET } from './internals/constants';
 import { blurIfNecessary, dismissAriaPopup } from './internals/interaction';
 
 /**
@@ -9,7 +9,7 @@ export function clear(
   prevSubject: unknown,
   options?: Partial<Cypress.ClearOptions>
 ) {
-  if (!isJQuery(prevSubject)) {
+  if (!Cypress.dom.isJquery(prevSubject)) {
     return originalFn(prevSubject, options);
   }
 

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -1,4 +1,4 @@
-import { QUIET, FORCE_QUIET, isQuery } from './internals/constants';
+import { QUIET, FORCE_QUIET, isJQuery } from './internals/constants';
 import { blurIfNecessary, dismissAriaPopup } from './internals/interaction';
 
 /**
@@ -10,7 +10,7 @@ export function clear(
   prevSubject: unknown,
   options?: Partial<Cypress.ClearOptions>
 ) {
-  if (!isQuery(prevSubject)) {
+  if (!isJQuery(prevSubject)) {
     return originalFn(prevSubject, options);
   }
 

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -1,32 +1,30 @@
-/// <reference types="cypress" />
-
-import { QUIET, FORCE_QUIET } from './internals/constants';
+import { QUIET, FORCE_QUIET, isQuery } from './internals/constants';
 import { blurIfNecessary, dismissAriaPopup } from './internals/interaction';
 
-type ClearFn = (
-  subject: JQuery,
-  options?: Cypress.ClearOptions
-) => Cypress.Chainable;
-
 /**
- * Clear an input or a gears Select component.
+ * Clear a vanilla HTML input or a fancy gears component e.g. Select.
  */
 export function clear(
-  originalClear: ClearFn,
-  subject: JQuery,
-  options?: Cypress.ClearOptions
+  this: Mocha.Context,
+  originalFn: Cypress.CommandOriginalFnWithSubject<'clear', unknown>,
+  prevSubject: unknown,
+  options?: Partial<Cypress.ClearOptions>
 ) {
-  if (subject.hasClass('Select-control')) {
+  if (!isQuery(prevSubject)) {
+    return originalFn(prevSubject, options);
+  }
+
+  if (prevSubject.hasClass('Select-control')) {
     if (!options || options.log !== false)
       Cypress.log({
         name: 'clear',
-        $el: subject,
+        $el: prevSubject,
         consoleProps: () => ({
-          'Applied to': Cypress.dom.getElements(subject),
+          'Applied to': Cypress.dom.getElements(prevSubject),
         }),
       });
 
-    const btn = subject.find('button.close');
+    const btn = prevSubject.find('button.close');
 
     // Use the "X" button to clear Select components.
     if (btn.length === 1)
@@ -35,21 +33,21 @@ export function clear(
         .click(FORCE_QUIET)
         .then(() => {
           // try to ensure that the popup disappears
-          blurIfNecessary(subject.find('input'));
-          return subject;
+          blurIfNecessary(prevSubject.find('input'));
+          return prevSubject;
         });
     // No "X" button; fall through to original cy.clear
     else
-      return originalClear(subject.find('input'), {
+      return originalFn(prevSubject.find('input'), {
         ...options,
         force: true,
         log: false,
       } as Cypress.ClearOptions).then(() => {
         // try to ensure that the popup disappears
-        blurIfNecessary(subject.find('input'));
-        return subject;
+        blurIfNecessary(prevSubject.find('input'));
+        return prevSubject;
       });
   }
   // For other inputs, use original cy.clear but also dismiss popups (e.g. DateInput).
-  return originalClear(subject, options).then(dismissAriaPopup);
+  return originalFn(prevSubject, options).then(dismissAriaPopup);
 }

--- a/src/commands/clear.ts
+++ b/src/commands/clear.ts
@@ -5,7 +5,6 @@ import { blurIfNecessary, dismissAriaPopup } from './internals/interaction';
  * Clear a vanilla HTML input or a fancy gears component e.g. Select.
  */
 export function clear(
-  this: Mocha.Context,
   originalFn: Cypress.CommandOriginalFnWithSubject<'clear', unknown>,
   prevSubject: unknown,
   options?: Partial<Cypress.ClearOptions>

--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -1,4 +1,4 @@
-import { isQuery } from './internals/constants';
+import { isJQuery } from './internals/constants';
 
 /**
  * Click something and deal with empty buttons that contain only an icon.
@@ -12,7 +12,7 @@ export function click(
   y: number,
   options?: Partial<Cypress.ClickOptions>
 ) {
-  if (!isQuery(prevSubject)) {
+  if (!isJQuery(prevSubject)) {
     return originalFn(prevSubject, x, y, options);
   }
   if (prevSubject.is('button') && prevSubject.text() === '') {

--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -1,5 +1,3 @@
-import { isJQuery } from './internals/constants';
-
 /**
  * Click something and deal with empty buttons that contain only an icon.
  * @deprecated this is not necessary since Cypress 10
@@ -11,7 +9,7 @@ export function click(
   y: number,
   options?: Partial<Cypress.ClickOptions>
 ) {
-  if (!isJQuery(prevSubject)) {
+  if (!Cypress.dom.isJquery(prevSubject)) {
     return originalFn(prevSubject, x, y, options);
   }
   if (prevSubject.is('button') && prevSubject.text() === '') {

--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -1,15 +1,22 @@
-type ClickFn = (
-  subject: JQuery,
-  options?: Partial<Cypress.ClickOptions>
-) => Cypress.Chainable;
+import { isQuery } from './internals/constants';
 
+/**
+ * Click something and deal with empty buttons that contain only an icon.
+ * @deprecated this is not necessary since Cypress 10
+ */
 export function click(
-  originalClick: ClickFn,
-  subject: JQuery,
+  this: Mocha.Context,
+  originalFn: Cypress.CommandOriginalFnWithSubject<'click', unknown>,
+  prevSubject: unknown,
+  x: number,
+  y: number,
   options?: Partial<Cypress.ClickOptions>
 ) {
-  if (subject.is('button') && subject.text() === '') {
-    return originalClick(subject, { ...options, force: true });
+  if (!isQuery(prevSubject)) {
+    return originalFn(prevSubject, x, y, options);
   }
-  return originalClick(subject, options);
+  if (prevSubject.is('button') && prevSubject.text() === '') {
+    return originalFn(prevSubject, x, y, { ...options, force: true });
+  }
+  return originalFn(prevSubject, x, y, options);
 }

--- a/src/commands/click.ts
+++ b/src/commands/click.ts
@@ -5,7 +5,6 @@ import { isJQuery } from './internals/constants';
  * @deprecated this is not necessary since Cypress 10
  */
 export function click(
-  this: Mocha.Context,
   originalFn: Cypress.CommandOriginalFnWithSubject<'click', unknown>,
   prevSubject: unknown,
   x: number,

--- a/src/commands/component.ts
+++ b/src/commands/component.ts
@@ -94,7 +94,6 @@ function mapAll($collection: JQuery, callback: ($el: JQuery) => JQuery) {
 }
 
 export function component(
-  this: Mocha.Context,
   prevSubject: JQuery | void,
   component: Component,
   ...rest: any[]

--- a/src/commands/component.ts
+++ b/src/commands/component.ts
@@ -12,14 +12,14 @@ import { getFirstDeepestElement } from './internals/driver';
 import { findAllByText, orderByInnerText } from './internals/text';
 
 declare global {
-  interface JQuery {
-    // /Cypress overrides some chai assertions to add command log entries, which
-    /// seem to rely on a hidden `selector` property of the JQuery in order to
-    /// describe what was found or not found. By setting this during our commands,
-    /// we can make the command log work much more like it would for vanilla
-    /// Cypress commands (e.g. mouseover to highlight element).
-    selector?: string;
-  }
+  // interface JQuery {
+  //   // /Cypress overrides some chai assertions to add command log entries, which
+  //   /// seem to rely on a hidden `selector` property of the JQuery in order to
+  //   /// describe what was found or not found. By setting this during our commands,
+  //   /// we can make the command log work much more like it would for vanilla
+  //   /// Cypress commands (e.g. mouseover to highlight element).
+  //   selector?: string;
+  // }
 }
 
 /**

--- a/src/commands/fill.ts
+++ b/src/commands/fill.ts
@@ -35,10 +35,14 @@ declare global {
  * input, textarea, or fancy input (e.g. calendar).
  */
 export function fill(
-  subject: JQuery,
+  prevSubject: JQuery,
   value: string,
-  options: FillOptions = { log: true }
+  options?: Partial<FillOptions>
 ) {
+  if (!options) {
+    options = { log: true };
+  }
+
   if (!value)
     throw new Error(
       'CypressError: `cy.fill()` cannot accept an empty string. You need to fill with a value, or `cy.clear()` to remove all values.'
@@ -48,24 +52,24 @@ export function fill(
   let logEntry: any;
   if (options.log !== false) {
     consoleProps = {
-      'Applied to': Cypress.dom.getElements(subject),
+      'Applied to': Cypress.dom.getElements(prevSubject),
       Value: value,
     };
 
     logEntry = Cypress.log({
       name: 'fill',
       message: value,
-      $el: subject,
+      $el: prevSubject,
       consoleProps: () => {
         return consoleProps;
       },
     });
   }
 
-  const isFancySelect = subject.hasClass('Select-control');
-  const isTextInput = subject.is('input');
-  const isTextArea = subject.is('textarea');
-  const isVanillaSelect = subject.is('select');
+  const isFancySelect = prevSubject.hasClass('Select-control');
+  const isTextInput = prevSubject.is('input');
+  const isTextArea = prevSubject.is('textarea');
+  const isVanillaSelect = prevSubject.is('select');
 
   if (isFancySelect) {
     if (logEntry) consoleProps.Type = 'React Select';
@@ -76,12 +80,12 @@ export function fill(
 
     // NB repeatedly re-finding elements relative to subject in order to
     // deal with DOM churn
-    cy.wrap(subject, QUIET).clear(QUIET);
-    cy.wrap(subject, QUIET)
+    cy.wrap(prevSubject, QUIET).clear(QUIET);
+    cy.wrap(prevSubject, QUIET)
       .find('input', QUIET)
       .focus(QUIET)
       .type(value, FORCE_QUICK_QUIET);
-    cy.wrap(subject, QUIET)
+    cy.wrap(prevSubject, QUIET)
       .parent(QUIET)
       .get('.Select-menu', QUIET)
       .contains('button', match.exact(value), QUIET)
@@ -90,7 +94,7 @@ export function fill(
     if (logEntry) consoleProps.Type = 'HTML input';
     return (
       cy
-        .wrap(subject, QUIET)
+        .wrap(prevSubject, QUIET)
         .clear(QUIET)
         .focus(QUIET)
         .type(value, FORCE_QUICK_QUIET)
@@ -102,7 +106,7 @@ export function fill(
     if (logEntry) consoleProps.Type = 'HTML textarea';
     return (
       cy
-        .wrap(subject, QUIET)
+        .wrap(prevSubject, QUIET)
         .clear(QUIET)
         .focus(QUIET)
         .type(value, FORCE_QUICK_QUIET)
@@ -111,10 +115,10 @@ export function fill(
     );
   } else if (isVanillaSelect) {
     if (logEntry) consoleProps.Type = 'HTML select';
-    return cy.wrap(subject, QUIET).select(value, FORCE_QUIET);
+    return cy.wrap(prevSubject, QUIET).select(value, FORCE_QUIET);
   } else {
     throw new Error(
-      `cy.fill: unsupported element ${subject[0].tagName.toLowerCase()}`
+      `cy.fill: unsupported element ${prevSubject[0].tagName.toLowerCase()}`
     );
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,7 +21,6 @@ type CommandName = 'clear' | 'fill' | 'component' | 'select' | 'click';
 export function add(...names: CommandName[]) {
   const all = !names.length;
   if (all || names.includes('clear'))
-    // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.overwrite('clear', clear);
   if (all || names.includes('fill'))
     // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,8 +23,7 @@ export function add(...names: CommandName[]) {
   if (all || names.includes('clear'))
     Cypress.Commands.overwrite('clear', clear);
   if (all || names.includes('fill'))
-    // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
-    Cypress.Commands.add('fill', { prevSubject: true }, fill);
+    Cypress.Commands.add('fill', { prevSubject: ['element'] }, fill);
   if (all || names.includes('component'))
     // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.add('component', { prevSubject: 'optional' }, component);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -32,6 +32,5 @@ export function add(...names: CommandName[]) {
     // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.overwrite('select', select);
   if (all || names.includes('click'))
-    // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.overwrite('click', click);
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -25,8 +25,7 @@ export function add(...names: CommandName[]) {
   if (all || names.includes('fill'))
     Cypress.Commands.add('fill', { prevSubject: ['element'] }, fill);
   if (all || names.includes('component'))
-    // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
-    Cypress.Commands.add('component', { prevSubject: 'optional' }, component);
+    Cypress.Commands.add('component', { prevSubject: ['optional'] }, component);
   if (all || names.includes('select'))
     // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.overwrite('select', select);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,7 +27,6 @@ export function add(...names: CommandName[]) {
   if (all || names.includes('component'))
     Cypress.Commands.add('component', { prevSubject: ['optional'] }, component);
   if (all || names.includes('select'))
-    // @ts-expect-error cypress(2769) works fine, just not compatible with modern Cypress typings
     Cypress.Commands.overwrite('select', select);
   if (all || names.includes('click'))
     Cypress.Commands.overwrite('click', click);

--- a/src/commands/internals/constants.ts
+++ b/src/commands/internals/constants.ts
@@ -3,3 +3,5 @@
 export const FORCE_QUICK_QUIET = { force: true, delay: 1, log: false };
 export const FORCE_QUIET = { force: true, log: false };
 export const QUIET = { log: false };
+
+export const isQuery = (u: unknown): u is JQuery => typeof u === 'object' && u && (u as any).jquery;

--- a/src/commands/internals/constants.ts
+++ b/src/commands/internals/constants.ts
@@ -3,6 +3,3 @@
 export const FORCE_QUICK_QUIET = { force: true, delay: 1, log: false };
 export const FORCE_QUIET = { force: true, log: false };
 export const QUIET = { log: false };
-
-export const isJQuery = (u: unknown): u is JQuery =>
-  typeof u === 'object' && u && (u as any).jquery;

--- a/src/commands/internals/constants.ts
+++ b/src/commands/internals/constants.ts
@@ -4,4 +4,5 @@ export const FORCE_QUICK_QUIET = { force: true, delay: 1, log: false };
 export const FORCE_QUIET = { force: true, log: false };
 export const QUIET = { log: false };
 
-export const isQuery = (u: unknown): u is JQuery => typeof u === 'object' && u && (u as any).jquery;
+export const isJQuery = (u: unknown): u is JQuery =>
+  typeof u === 'object' && u && (u as any).jquery;

--- a/src/commands/internals/driver.ts
+++ b/src/commands/internals/driver.ts
@@ -27,7 +27,7 @@ const getParentNode = (el: HTMLElement) => {
   // if the element is inside a shadow root,
   // return the host of the root.
   if (root && isWithinShadowRoot(el)) {
-    // @ts-ignore:2339
+    // @ts-expect-error dom(2339)
     return root.host;
   }
 

--- a/src/commands/internals/interaction.ts
+++ b/src/commands/internals/interaction.ts
@@ -3,7 +3,7 @@
 import { FORCE_QUIET } from './constants';
 
 export function blurIfNecessary(subject: JQuery) {
-  // @ts-ignore:2339
+  // @ts-expect-error cypress(2339) undocumented command
   if (subject.is(':focus')) cy.now('blur', subject, FORCE_QUIET);
   return subject;
 }

--- a/src/commands/internals/interaction.ts
+++ b/src/commands/internals/interaction.ts
@@ -3,7 +3,6 @@
 import { FORCE_QUIET } from './constants';
 
 export function blurIfNecessary(subject: JQuery) {
-  // @ts-expect-error cypress(2339) undocumented command
   if (subject.is(':focus')) cy.now('blur', subject, FORCE_QUIET);
   return subject;
 }

--- a/src/commands/select.ts
+++ b/src/commands/select.ts
@@ -1,16 +1,20 @@
 import * as match from '../match';
-import { FORCE_QUIET, QUIET } from './internals/constants';
+import { FORCE_QUIET, QUIET, isJQuery } from './internals/constants';
 
 /**
  * Choose a value from a select (either vanilla HTML or gears).
  */
 export function select(
   this: Mocha.Context,
-  originalFn: Cypress.CommandOriginalFnWithSubject<'select', JQuery>,
-  prevSubject: JQuery,
+  originalFn: Cypress.CommandOriginalFnWithSubject<'select', unknown>,
+  prevSubject: unknown,
   valueOrTextOrIndex: string | number | (string | number)[],
   options?: Partial<Cypress.SelectOptions>
 ) {
+  if (!isJQuery(prevSubject)) {
+    return originalFn(prevSubject, valueOrTextOrIndex, options);
+  }
+
   if (prevSubject.hasClass('Select-control')) {
     if (!options || options.log !== false)
       Cypress.log({
@@ -22,9 +26,9 @@ export function select(
         }),
       });
 
-    if (Array.isArray(valueOrTextOrIndex))
+    if (typeof valueOrTextOrIndex !== 'string')
       throw new Error(
-        'gears Select multi not yet supported; have fun implementing!'
+        'react-gears-cypress: Select multi not yet supported; have fun implementing!'
       );
     cy.wrap(prevSubject, QUIET).within(() => {
       cy.get('input', QUIET)

--- a/src/commands/select.ts
+++ b/src/commands/select.ts
@@ -5,7 +5,6 @@ import { FORCE_QUIET, QUIET, isJQuery } from './internals/constants';
  * Choose a value from a select (either vanilla HTML or gears).
  */
 export function select(
-  this: Mocha.Context,
   originalFn: Cypress.CommandOriginalFnWithSubject<'select', unknown>,
   prevSubject: unknown,
   valueOrTextOrIndex: string | number | (string | number)[],

--- a/src/commands/select.ts
+++ b/src/commands/select.ts
@@ -1,5 +1,5 @@
 import * as match from '../match';
-import { FORCE_QUIET, QUIET, isJQuery } from './internals/constants';
+import { FORCE_QUIET, QUIET } from './internals/constants';
 
 /**
  * Choose a value from a select (either vanilla HTML or gears).
@@ -10,7 +10,7 @@ export function select(
   valueOrTextOrIndex: string | number | (string | number)[],
   options?: Partial<Cypress.SelectOptions>
 ) {
-  if (!isJQuery(prevSubject)) {
+  if (!Cypress.dom.isJquery(prevSubject)) {
     return originalFn(prevSubject, valueOrTextOrIndex, options);
   }
 

--- a/src/components.ts
+++ b/src/components.ts
@@ -39,7 +39,7 @@ export const Input: ComponentWithText = {
   name: 'Input',
   query: ':not(.Select) input,textarea',
   textQuery: ':not(:has(select,.Select)) label',
-  traverseViaText: $el => {
+  traverseViaText: ($el) => {
     const forId = $el.attr('for');
 
     if (forId) {

--- a/src/findNegative.ts
+++ b/src/findNegative.ts
@@ -9,7 +9,7 @@
 import { Color, Text } from '.';
 import * as components from './components';
 
-declare var cy: Cypress.Chainable;
+declare let cy: Cypress.Chainable;
 
 // @deprecated please use cy.component() with Component definitions and .should('not.exist')
 export function alert(text: Text, color?: Color) {

--- a/src/match.ts
+++ b/src/match.ts
@@ -33,4 +33,7 @@ export const fuzzyFirstLast = (first: string, last: string) =>
 // Good for dealing with HTML elements that have a multi-line value, but need to be matched with a
 // value from single-line Gherkin table cell. (cucumber-js doesn't grok \n unfortunately!)
 export const fuzzyMultiline = (value: string) =>
-  new RegExp(`^${Cypress._.escapeRegExp(value)}\\s*$`.replace(/\s+/g, '\\s+'), 'm');
+  new RegExp(
+    `^${Cypress._.escapeRegExp(value)}\\s*$`.replace(/\s+/g, '\\s+'),
+    'm'
+  );


### PR DESCRIPTION
No functional change, but this prepares us to redo `cy.component` as a query to dramatically mitigate DOM churn -- and might let us drop the overridden `click` command (needs testing).